### PR TITLE
Adds client multiple redirect_uri (Closes #8)

### DIFF
--- a/lib/oidc_provider/client.rb
+++ b/lib/oidc_provider/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OIDCProvider
   class Client
     attr_accessor :identifier, :secret, :redirect_uri, :name
@@ -5,7 +7,7 @@ module OIDCProvider
     def initialize(options = {})
       @identifier = options[:identifier]
       @secret = options[:secret]
-      @redirect_uri = options[:redirect_uri]
+      @redirect_uri = Array(options[:redirect_uri])
       @name = options[:name]
     end
   end

--- a/lib/oidc_provider/token_endpoint.rb
+++ b/lib/oidc_provider/token_endpoint.rb
@@ -38,7 +38,7 @@ module OIDCProvider
         secret: req.client_secret
       )
 
-      return false unless client
+      return nil unless client
 
       client.redirect_uri.include?(req.redirect_uri) ? client : nil
     end

--- a/lib/oidc_provider/token_endpoint.rb
+++ b/lib/oidc_provider/token_endpoint.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 module OIDCProvider
   class TokenEndpoint
     attr_accessor :app
+
     delegate :call, to: :app
 
     def initialize
@@ -8,26 +11,36 @@ module OIDCProvider
         Rails.logger.info "Client ID: #{req.client_id}"
         Rails.logger.info "Client secret: #{req.client_secret}"
         Rails.logger.info "Redirect URI: #{req.redirect_uri}"
-        client = ClientStore.new.find_by(
-          identifier: req.client_id,
-          secret: req.client_secret,
-          redirect_uri: req.redirect_uri
-        ) || req.invalid_client!
-        
-        Rails.logger.info "Found a client!"
+
+        client = find_valid_client_from(req) || req.invalid_client!
+
+        Rails.logger.info 'Found a client!'
 
         case req.grant_type
         when :authorization_code
-          Rails.logger.info "Grant type was an authorization code. Correct!"
+          Rails.logger.info 'Grant type was an authorization code. Correct!'
           authorization = Authorization.valid.where(client_id: client.identifier, code: req.code).first || req.invalid_grant!
-          Rails.logger.info "We found an authorization matching this code!"
+          Rails.logger.info 'We found an authorization matching this code!'
           res.access_token = authorization.access_token.to_bearer_token
-          res.id_token = authorization.id_token.to_jwt if authorization.scopes.include?("openid")
+          res.id_token = authorization.id_token.to_jwt if authorization.scopes.include?('openid')
         else
-          Rails.logger.info "Unsupported grant type"
+          Rails.logger.info "Unsupported grant type: #{req.grant_type.inspect}"
           req.unsupported_grant_type!
         end
       end
+    end
+
+    private
+
+    def find_valid_client_from(req)
+      client = ClientStore.new.find_by(
+        identifier: req.client_id,
+        secret: req.client_secret
+      )
+
+      return false unless client
+
+      client.redirect_uri.include?(req.redirect_uri) ? client : nil
     end
   end
 end


### PR DESCRIPTION
This PR supersedes #9.

This PR allows one to configure a client with multiple `redirect_uri` AND fixes the way to check passed `redirect_uri` as described in #8.\
I have also improve a little bit the code at some places around the updated code.

Closes #8.