### PR TITLE
Allows setting private key file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ rails db:migrate
 
 This gem signs the generated [JWT (JSON Web Tokens)](https://jwt.io/) using a
 private key that should exist at the path `lib/oidc_provider_key.pem` in your
-Rails application.
+Rails application (or in the path defined in the OIDC_PROVIDER_PRIVATE_KEY_PATH).
 
 You can pass its passphrase using the `OIDC_PROVIDER_KEY_PASSPHRASE` environment
 variable.

--- a/app/models/oidc_provider/id_token.rb
+++ b/app/models/oidc_provider/id_token.rb
@@ -36,7 +36,7 @@ module OIDCProvider
       end
 
       def oidc_provider_key_path
-        Rails.root.join("lib/oidc_provider_key.pem")
+        ENV.fetch('OIDC_PROVIDER_PRIVATE_KEY_PATH', Rails.root.join('lib/oidc_provider_key.pem'))
       end
 
       def key_pair

--- a/lib/tasks/oidc_provider.rake
+++ b/lib/tasks/oidc_provider.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :oidc_provider do
-  desc 'Generate the lib/oidc_provider_key.pem key file'
+  desc 'Generate the oidc_provider_key.pem key file'
   task generate_key: :environment do
     key_filepath = OIDCProvider::IdToken.oidc_provider_key_path
 


### PR DESCRIPTION
Using the environment variable `OIDC_PROVIDER_PRIVATE_KEY_PATH` you can define a different place where that file should be.

In our use case, using Kubernetes, we need to mount that file but the `lib/` folder is not empty and therefore moving that file somewhere else makes it easier to manage.